### PR TITLE
Fix - Wrong dates selection with custom firstDayOfWeek

### DIFF
--- a/src/api/View.ts
+++ b/src/api/View.ts
@@ -10,7 +10,8 @@ export default function build(options: BuildViewOptions = {}): BuildViewResult {
   const firstDayOfWeek = options.firstDayOfWeek ?? DEFAULTS.firstDayOfWeek
 
   const date = Temporal.PlainDate.from(options.date || Temporal.Now.plainDateISO())
-  const start = date.add({ days: (firstDayOfWeek - date.dayOfWeek) % 7 })
+  const daysFromWeekStart = (date.dayOfWeek - firstDayOfWeek + 7) % 7
+  const start = date.subtract({ days: daysFromWeekStart })
   const dates = Array.from({ length: nWeeks * 7 }, (_v, i) => start.add({ days: i }).toString())
 
   return {


### PR DESCRIPTION
The `dates` calculated from the provided `date` in `api/view` were being wrongly calculated if the `firstDayOfWeek` was something different from the default. Instead of selecting the week containing `date`, it would set `dates` to be the week starting from the next instance of `firstDayOfWeek`.

For example, when `firstDayOfWeek` is set to friday (5) and `date` to today (2025-06-16), `dates` would be from the 20th to the 26th, which doesn't include `date`. After the fix, they would be the week starting on a `firstDayOfWeek` than includes `date`, that is, from the 13th to the 19th.

Before:
![CleanShot 2025-06-16 at 18 13 00@2x](https://github.com/user-attachments/assets/860eddba-4dab-4730-b93a-dfa599f8ebe7)

After:
![CleanShot 2025-06-16 at 18 13 27@2x](https://github.com/user-attachments/assets/ad0ff5d1-1ac1-4e2b-bcdd-87f20e239b8f)
